### PR TITLE
Address testing pipeline failures.

### DIFF
--- a/.github/workflows/python-app.yml
+++ b/.github/workflows/python-app.yml
@@ -18,6 +18,11 @@ jobs:
       matrix:
         os: ["windows-latest", "ubuntu-latest", "macos-latest"]
         python-version: ["3.8", "3.9", "3.10", "3.11", "3.12"]
+        exclude:
+          - os: macos-latest
+            python-version: "3.8"
+          - os: macos-latest
+            python-version: "3.9"
 
     steps:
     - uses: actions/checkout@v2

--- a/.github/workflows/python-app.yml
+++ b/.github/workflows/python-app.yml
@@ -17,10 +17,8 @@ jobs:
       fail-fast: false
       matrix:
         os: ["windows-latest", "ubuntu-latest", "macos-latest"]
-        python-version: ["3.8", "3.9", "3.10", "3.11", "3.12"]
+        python-version: ["3.9", "3.10", "3.11", "3.12"]
         exclude:
-          - os: macos-latest
-            python-version: "3.8"
           - os: macos-latest
             python-version: "3.9"
 

--- a/openzgy/impl/genlod.py
+++ b/openzgy/impl/genlod.py
@@ -51,9 +51,9 @@ def _make_blocksizes(bricksize, surveysize, nlods, dtype, factor=(1,1,1), verbos
     for lod in range(nlods):
         bs = np.minimum(bs, ss)
         blocksizes[lod] = bs
-        iterations += np.product((ss+bs-1) // bs)
+        iterations += np.prod((ss+bs-1) // bs)
         ss = (ss + 1) // 2
-    bytesused = np.sum(np.product(blocksizes, axis=1)) * int(np.dtype(dtype).itemsize)
+    bytesused = np.sum(np.prod(blocksizes, axis=1)) * int(np.dtype(dtype).itemsize)
     returntype = namedtuple("BlockSizeInfo", "blocksizes bytesused iterations")
     result = returntype(blocksizes, bytesused, iterations)
     print(result)
@@ -140,7 +140,7 @@ class GenLodBase:
         sz = np.array(size, dtype=np.int64)
         while np.any(sz > bs):
             _nlods += 1
-            _total += np.product((sz + bs - 1) // bs)
+            _total += np.prod((sz + bs - 1) // bs)
             sz = (sz + 1) // 2
         assert nlods is None or nlods == _nlods
         self._surveysize = np.array(size, dtype=np.int64)
@@ -172,7 +172,7 @@ class GenLodBase:
         _total done in __init__ might need to change.
         """
         if data is not None:
-            count = np.product((np.array(data.shape, dtype=np.int64) +
+            count = np.prod((np.array(data.shape, dtype=np.int64) +
                                 self._bricksize - 1) // self._bricksize)
             self._done += count
         if self._progress and not self._progress(self._done, self._total):
@@ -256,7 +256,7 @@ class GenLodImpl(GenLodBase):
             return
         factor = 1
         if isinstance(data, ScalarBuffer):
-            factor = np.product(data.shape, dtype=np.int64)
+            factor = np.prod(data.shape, dtype=np.int64)
             data = np.array([data.value], dtype=data.dtype)
         self._stats.add(data, factor)
         self._histo.add(data, factor)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,7 +7,7 @@ authors = [
 description = "Convenience wrapper around OpenZGY Python implementation"
 readme = {file = "README.rst", content-type = "text/markdown"}
 dependencies = [
-    "numpy>=1.20", "segyio", "xarray"
+    "numpy>=1.20", "segyio", "xarray", "dask"
 ]
 requires-python = ">=3.8"
 license = {file = "LICENSE.txt"}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,7 +9,7 @@ readme = {file = "README.rst", content-type = "text/markdown"}
 dependencies = [
     "numpy>=1.20", "segyio", "xarray", "dask"
 ]
-requires-python = ">=3.8"
+requires-python = ">=3.9"
 license = {file = "LICENSE.txt"}
 classifiers = [
     "License :: OSI Approved :: Apache Software License"

--- a/pyzgy/xarray.py
+++ b/pyzgy/xarray.py
@@ -1,7 +1,6 @@
 import itertools
 from dataclasses import dataclass
-from typing import Any, Dict, Tuple, List
-from enum import Enum
+from typing import Union
 
 import numpy as np
 import xarray as xr
@@ -139,8 +138,8 @@ class PyzgyBackendEntrypoint(BackendEntrypoint):
                 "xline": reader.xlines,
             }
             dims_vert = {"samples": reader.samples}
-
-            ds = xr.Dataset(coords=dims | dims_vert)
+            dims.update(dims_vert)
+            ds = xr.Dataset(coords=dims)
 
             # load attributes
             ds.attrs[AttrKeyField.source_file] = str(filename_or_obj)
@@ -163,8 +162,8 @@ class PyzgyBackendEntrypoint(BackendEntrypoint):
 
     def open_dataset(
         self,
-        filename_or_obj: str | os.PathLike,
-        drop_variables: tuple[str] | None = None,
+        filename_or_obj: Union[str, os.PathLike],
+        drop_variables: Union[tuple[str], None] = None,
     ):
         zgy_shape, ds = self._create_geometry_ds(filename_or_obj)
         backend_array = ZgyBackendArray(
@@ -184,7 +183,7 @@ class PyzgyBackendEntrypoint(BackendEntrypoint):
         ds["data"] = xr.Variable(ds.dims, data, encoding=encoding)
         return ds
 
-    def guess_can_open(self, filename_or_obj: str | os.PathLike):
+    def guess_can_open(self, filename_or_obj: Union[str, os.PathLike]):
         try:
             _, ext = os.path.splitext(filename_or_obj)
         except TypeError:


### PR DESCRIPTION
Revert `|` operators for typing to `typing.Union`
Update Github Actions to remove Python 3.8 tests and MacOSX tests on x64.
Set package requires python >=3.9
Add dask as requirement.